### PR TITLE
remove point and version for accessibility

### DIFF
--- a/src/ebook-speaker.c
+++ b/src/ebook-speaker.c
@@ -711,7 +711,7 @@ void view_screen (misc_t *misc, daisy_t *daisy)
       if (l / 2 * 2 == l)
          waddstr (misc->screenwin, " ");
       for (x = l; x < 56; x += 2)
-         waddstr (misc->screenwin, " .");
+         waddstr (misc->screenwin, "  ");
       if (daisy[i].page_number)
       {
          mvwprintw (misc->screenwin, daisy[i].y, 63,
@@ -2926,8 +2926,8 @@ int main (int argc, char *argv[])
    noecho ();
    misc.player_pid = -2;
    sprintf (misc.scan_resolution, "400");
-   snprintf (misc.copyright, MAX_STR - 1, "%s %s - (C)2021 J. Lemmens",
-             gettext ("eBook-speaker - Version"), PACKAGE_VERSION);
+   snprintf (misc.copyright, MAX_STR - 1, "%s                        ",
+             gettext ("eBook-speaker          "));
    wattron (misc.titlewin, A_BOLD);
    wprintw (misc.titlewin, "%s - %s", misc.copyright,
             gettext ("Please wait..."));

--- a/src/list_dir.c
+++ b/src/list_dir.c
@@ -82,8 +82,33 @@ void ls (misc_t *misc, size_t n, struct dirent **namelist)
 
 int hidden_files (const struct dirent *entry)
 {
+
+int      r = 0;
+char     my_pattern1[] = "*.jpg";
+char     my_pattern2[] = "*.opf";
+char     my_pattern3[] = "*.pdf";
+char     my_pattern4[] = "*.db";
+char     my_pattern5[] = "*.json";
+
    if (*entry->d_name == '.')
       return 0;
+
+   r = fnmatch (my_pattern1, entry->d_name, FNM_PERIOD | FNM_CASEFOLD);
+   if (r == 0)
+      return 0;
+   r = fnmatch (my_pattern2, entry->d_name, FNM_PERIOD | FNM_CASEFOLD);
+   if (r == 0)
+      return 0;
+   r = fnmatch (my_pattern3, entry->d_name, FNM_PERIOD | FNM_CASEFOLD);
+   if (r == 0)
+      return 0;
+   r = fnmatch (my_pattern4, entry->d_name, FNM_PERIOD | FNM_CASEFOLD);
+   if (r == 0)
+      return 0;
+   r = fnmatch (my_pattern5, entry->d_name, FNM_PERIOD | FNM_CASEFOLD);
+   if (r == 0)
+      return 0;
+
    return 1;
 } // hidden)files
 


### PR DESCRIPTION
Hi @sthibaul 

The Pull Request for this ticket https://github.com/book-readers/ebook-speaker/issues/7 for only this points :

- Remove the periods between the chapter titles and the page number
- Remove the version, the name of the author in the top banner

For this point :
- Filter the files jeg, opf, displayed in the file explorer

I can make this modification, but there is an impact because future users will not be able to see certain files in ebook-speaker's file explorer.